### PR TITLE
Add tracepoint for generic publisher/subscriber

### DIFF
--- a/rclcpp/include/rclcpp/generic_subscription.hpp
+++ b/rclcpp/include/rclcpp/generic_subscription.hpp
@@ -84,13 +84,23 @@ public:
       options.event_callbacks,
       options.use_default_callbacks,
       DeliveredMessageKind::SERIALIZED_MESSAGE),
-    callback_([callback](
-        std::shared_ptr<const rclcpp::SerializedMessage> serialized_message,
-        const rclcpp::MessageInfo & message_info) mutable {
-        callback.dispatch(serialized_message, message_info);
-      }),
+    any_callback_(callback),
     ts_lib_(ts_lib)
-  {}
+  {
+    auto callback_ptr = static_cast<const void *>(&any_callback_);
+    TRACETOOLS_TRACEPOINT(
+      rclcpp_subscription_init,
+      static_cast<const void *>(get_subscription_handle().get()),
+      static_cast<const void *>(this));
+    TRACETOOLS_TRACEPOINT(
+      rclcpp_subscription_callback_added,
+      static_cast<const void *>(this),
+      callback_ptr);
+
+#ifndef TRACETOOLS_DISABLED
+    any_callback_.register_callback_for_tracing();
+#endif
+  }
 
   RCLCPP_PUBLIC
   virtual ~GenericSubscription() = default;
@@ -153,10 +163,8 @@ public:
 
 private:
   RCLCPP_DISABLE_COPY(GenericSubscription)
-
-  std::function<void(
-      std::shared_ptr<const rclcpp::SerializedMessage>,
-      const rclcpp::MessageInfo)> callback_;
+  
+  AnySubscriptionCallback<rclcpp::SerializedMessage, std::allocator<void>> any_callback_;
   // The type support library should stay loaded, so it is stored in the GenericSubscription
   std::shared_ptr<rcpputils::SharedLibrary> ts_lib_;
 };

--- a/rclcpp/include/rclcpp/node_interfaces/detail/node_interfaces_helpers.hpp
+++ b/rclcpp/include/rclcpp/node_interfaces/detail/node_interfaces_helpers.hpp
@@ -167,6 +167,7 @@ init_tuple(NodeT & n)
  * something like that, then you'll need to create your own specialization of
  * the NodeInterfacesSupports struct without this macro.
  */
+// *INDENT-OFF*
 #define RCLCPP_NODE_INTERFACE_HELPERS_SUPPORT(NodeInterfaceType, NodeInterfaceName) \
   namespace rclcpp::node_interfaces::detail { \
   template<typename StorageClassT, typename ... RemainingInterfaceTs> \
@@ -189,7 +190,7 @@ init_tuple(NodeT & n)
     /* Perfect forwarding constructor to get arguments down to StorageClassT (eventually). */ \
     template<typename ... ArgsT> \
     explicit NodeInterfacesSupports(ArgsT && ... args) \
-      : NodeInterfacesSupports<StorageClassT, RemainingInterfaceTs ...>( \
+    : NodeInterfacesSupports<StorageClassT, RemainingInterfaceTs ...>( \
         std::forward<ArgsT>(args) ...) \
     {} \
  \
@@ -200,6 +201,7 @@ init_tuple(NodeT & n)
     } \
   }; \
   }  // namespace rclcpp::node_interfaces::detail
+// *INDENT-ON*
 
 }  // namespace detail
 }  // namespace node_interfaces

--- a/rclcpp/include/rclcpp/subscription.hpp
+++ b/rclcpp/include/rclcpp/subscription.hpp
@@ -127,6 +127,7 @@ public:
    *   of the following conditions are true: qos_profile.history == RMW_QOS_POLICY_HISTORY_KEEP_ALL,
    *   qos_profile.depth == 0 or qos_profile.durability != RMW_QOS_POLICY_DURABILITY_VOLATILE).
    */
+  // *INDENT-OFF*
   Subscription(
     rclcpp::node_interfaces::NodeBaseInterface * node_base,
     const rosidl_message_type_support_t & type_support_handle,
@@ -148,6 +149,7 @@ public:
     any_callback_(callback),
     options_(options),
     message_memory_strategy_(message_memory_strategy)
+  // *INDENT-ON*
   {
     // Setup intra process publishing if requested.
     if (rclcpp::detail::resolve_use_intra_process(options_, *node_base)) {

--- a/rclcpp/include/rclcpp/time.hpp
+++ b/rclcpp/include/rclcpp/time.hpp
@@ -57,6 +57,10 @@ public:
   RCLCPP_PUBLIC
   Time(const Time & rhs);
 
+  /// Move constructor
+  RCLCPP_PUBLIC
+  Time(Time && rhs) noexcept;
+
   /// Time constructor
   /**
    * \param time_msg builtin_interfaces time message to copy
@@ -84,6 +88,7 @@ public:
   operator builtin_interfaces::msg::Time() const;
 
   /**
+   * Copy assignment operator
    * \throws std::runtime_error if seconds are negative
    */
   RCLCPP_PUBLIC
@@ -99,6 +104,13 @@ public:
   RCLCPP_PUBLIC
   Time &
   operator=(const builtin_interfaces::msg::Time & time_msg);
+
+  /**
+   * Move assignment operator
+   */
+  RCLCPP_PUBLIC
+  Time &
+  operator=(Time && rhs) noexcept;
 
   /**
    * \throws std::runtime_error if the time sources are different

--- a/rclcpp/src/rclcpp/executor.cpp
+++ b/rclcpp/src/rclcpp/executor.cpp
@@ -95,8 +95,9 @@ Executor::~Executor()
   }
   // Disassociate all nodes.
   std::for_each(
-    weak_nodes_.begin(), weak_nodes_.end(), []
-      (rclcpp::node_interfaces::NodeBaseInterface::WeakPtr weak_node_ptr) {
+    weak_nodes_.begin(), weak_nodes_.end(),
+    [](rclcpp::node_interfaces::NodeBaseInterface::WeakPtr weak_node_ptr)
+    {
       auto shared_node_ptr = weak_node_ptr.lock();
       if (shared_node_ptr) {
         std::atomic_bool & has_executor = shared_node_ptr->get_associated_with_executor_atomic();

--- a/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
+++ b/rclcpp/src/rclcpp/executors/static_executor_entities_collector.cpp
@@ -409,8 +409,10 @@ StaticExecutorEntitiesCollector::remove_node(
   std::for_each(
     weak_groups_to_nodes_associated_with_executor_.begin(),
     weak_groups_to_nodes_associated_with_executor_.end(),
-    [&found_group_ptrs, node_ptr](std::pair<rclcpp::CallbackGroup::WeakPtr,
-    rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> key_value_pair) {
+    [&found_group_ptrs, node_ptr](
+      std::pair<rclcpp::CallbackGroup::WeakPtr,
+      rclcpp::node_interfaces::NodeBaseInterface::WeakPtr> key_value_pair)
+    {
       auto & weak_node_ptr = key_value_pair.second;
       auto shared_node_ptr = weak_node_ptr.lock();
       auto group_ptr = key_value_pair.first.lock();
@@ -419,8 +421,9 @@ StaticExecutorEntitiesCollector::remove_node(
       }
     });
   std::for_each(
-    found_group_ptrs.begin(), found_group_ptrs.end(), [this]
-      (rclcpp::CallbackGroup::SharedPtr group_ptr) {
+    found_group_ptrs.begin(), found_group_ptrs.end(),
+    [this](rclcpp::CallbackGroup::SharedPtr group_ptr)
+    {
       this->remove_callback_group_from_map(
         group_ptr,
         weak_groups_to_nodes_associated_with_executor_);

--- a/rclcpp/src/rclcpp/generic_publisher.cpp
+++ b/rclcpp/src/rclcpp/generic_publisher.cpp
@@ -23,6 +23,9 @@ namespace rclcpp
 
 void GenericPublisher::publish(const rclcpp::SerializedMessage & message)
 {
+  TRACETOOLS_TRACEPOINT(rclcpp_publish,
+    static_cast<const void *>(publisher_handle_.get()),
+    static_cast<const void *>(&message.get_rcl_serialized_message()));
   auto return_code = rcl_publish_serialized_message(
     get_publisher_handle().get(), &message.get_rcl_serialized_message(), NULL);
 
@@ -68,6 +71,7 @@ void GenericPublisher::deserialize_message(
 
 void GenericPublisher::publish_loaned_message(void * loaned_message)
 {
+  TRACETOOLS_TRACEPOINT(rclcpp_publish, nullptr, static_cast<const void *>(loaned_message));
   auto return_code = rcl_publish_loaned_message(
     get_publisher_handle().get(), loaned_message, NULL);
 

--- a/rclcpp/src/rclcpp/generic_subscription.cpp
+++ b/rclcpp/src/rclcpp/generic_subscription.cpp
@@ -51,7 +51,7 @@ GenericSubscription::handle_serialized_message(
   const std::shared_ptr<rclcpp::SerializedMessage> & message,
   const rclcpp::MessageInfo & message_info)
 {
-  callback_(message, message_info);
+  any_callback_.dispatch(message,message_info);
 }
 
 void

--- a/rclcpp/src/rclcpp/time.cpp
+++ b/rclcpp/src/rclcpp/time.cpp
@@ -65,6 +65,8 @@ Time::Time(int64_t nanoseconds, rcl_clock_type_t clock_type)
 
 Time::Time(const Time & rhs) = default;
 
+Time::Time(Time && rhs) noexcept = default;
+
 Time::Time(
   const builtin_interfaces::msg::Time & time_msg,
   rcl_clock_type_t clock_type)
@@ -84,9 +86,7 @@ Time::Time(const rcl_time_point_t & time_point)
   // noop
 }
 
-Time::~Time()
-{
-}
+Time::~Time() = default;
 
 Time::operator builtin_interfaces::msg::Time() const
 {
@@ -102,6 +102,9 @@ Time::operator=(const builtin_interfaces::msg::Time & time_msg)
   *this = Time(time_msg);
   return *this;
 }
+
+Time &
+Time::operator=(Time && rhs) noexcept = default;
 
 bool
 Time::operator==(const rclcpp::Time & rhs) const

--- a/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/strategies/test_allocator_memory_strategy.cpp
@@ -200,9 +200,9 @@ protected:
 
   std::shared_ptr<rclcpp::Node> create_node_with_service(const std::string & name)
   {
-    auto service_callback =
-      [](const test_msgs::srv::Empty::Request::SharedPtr,
-        test_msgs::srv::Empty::Response::SharedPtr) {};
+    auto service_callback = [](
+      const test_msgs::srv::Empty::Request::SharedPtr,
+      test_msgs::srv::Empty::Response::SharedPtr) {};
     auto node_with_service = create_node_with_disabled_callback_groups(name);
 
     auto callback_group =
@@ -949,9 +949,9 @@ TEST_F(TestAllocatorMemoryStrategy, get_next_service_out_of_scope) {
       node->create_callback_group(
       rclcpp::CallbackGroupType::MutuallyExclusive);
 
-    auto service_callback =
-      [](const test_msgs::srv::Empty::Request::SharedPtr,
-        test_msgs::srv::Empty::Response::SharedPtr) {};
+    auto service_callback = [](
+      const test_msgs::srv::Empty::Request::SharedPtr,
+      test_msgs::srv::Empty::Response::SharedPtr) {};
     auto service = node->create_service<test_msgs::srv::Empty>(
       "service", std::move(service_callback), rclcpp::ServicesQoS(), callback_group);
 

--- a/rclcpp/test/rclcpp/test_any_service_callback.cpp
+++ b/rclcpp/test/rclcpp/test_any_service_callback.cpp
@@ -51,8 +51,10 @@ TEST_F(TestAnyServiceCallback, no_set_and_dispatch_throw) {
 
 TEST_F(TestAnyServiceCallback, set_and_dispatch_no_header) {
   int callback_calls = 0;
-  auto callback = [&callback_calls](const std::shared_ptr<test_msgs::srv::Empty::Request>,
-      std::shared_ptr<test_msgs::srv::Empty::Response>) {
+  auto callback = [&callback_calls](
+    const std::shared_ptr<test_msgs::srv::Empty::Request>,
+    std::shared_ptr<test_msgs::srv::Empty::Response>)
+    {
       callback_calls++;
     };
 
@@ -65,10 +67,11 @@ TEST_F(TestAnyServiceCallback, set_and_dispatch_no_header) {
 
 TEST_F(TestAnyServiceCallback, set_and_dispatch_header) {
   int callback_with_header_calls = 0;
-  auto callback_with_header =
-    [&callback_with_header_calls](const std::shared_ptr<rmw_request_id_t>,
-      const std::shared_ptr<test_msgs::srv::Empty::Request>,
-      std::shared_ptr<test_msgs::srv::Empty::Response>) {
+  auto callback_with_header = [&callback_with_header_calls](
+    const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<test_msgs::srv::Empty::Request>,
+    std::shared_ptr<test_msgs::srv::Empty::Response>)
+    {
       callback_with_header_calls++;
     };
 
@@ -80,9 +83,9 @@ TEST_F(TestAnyServiceCallback, set_and_dispatch_header) {
 
 TEST_F(TestAnyServiceCallback, set_and_dispatch_defered) {
   int callback_with_header_calls = 0;
-  auto callback_with_header =
-    [&callback_with_header_calls](const std::shared_ptr<rmw_request_id_t>,
-      const std::shared_ptr<test_msgs::srv::Empty::Request>) {
+  auto callback_with_header = [&callback_with_header_calls](
+    const std::shared_ptr<rmw_request_id_t>, const std::shared_ptr<test_msgs::srv::Empty::Request>)
+    {
       callback_with_header_calls++;
     };
 
@@ -94,10 +97,10 @@ TEST_F(TestAnyServiceCallback, set_and_dispatch_defered) {
 
 TEST_F(TestAnyServiceCallback, set_and_dispatch_defered_with_service_handle) {
   int callback_with_header_calls = 0;
-  auto callback_with_header =
-    [&callback_with_header_calls](std::shared_ptr<rclcpp::Service<test_msgs::srv::Empty>>,
-      const std::shared_ptr<rmw_request_id_t>,
-      const std::shared_ptr<test_msgs::srv::Empty::Request>)
+  auto callback_with_header = [&callback_with_header_calls](
+    std::shared_ptr<rclcpp::Service<test_msgs::srv::Empty>>,
+    const std::shared_ptr<rmw_request_id_t>,
+    const std::shared_ptr<test_msgs::srv::Empty::Request>)
     {
       callback_with_header_calls++;
     };

--- a/rclcpp/test/rclcpp/test_memory_strategy.cpp
+++ b/rclcpp/test/rclcpp/test_memory_strategy.cpp
@@ -143,9 +143,9 @@ TEST_F(TestMemoryStrategy, get_service_by_handle) {
     {
       auto callback_group =
         node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-      auto service_callback =
-        [](const test_msgs::srv::Empty::Request::SharedPtr,
-          test_msgs::srv::Empty::Response::SharedPtr) {};
+      auto service_callback = [](
+        const test_msgs::srv::Empty::Request::SharedPtr,
+        test_msgs::srv::Empty::Response::SharedPtr) {};
       const rclcpp::QoS qos(10);
       weak_groups_to_nodes.insert(
         std::pair<rclcpp::CallbackGroup::WeakPtr,
@@ -389,9 +389,9 @@ TEST_F(TestMemoryStrategy, get_group_by_service) {
     {
       auto callback_group =
         node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
-      auto service_callback =
-        [](const test_msgs::srv::Empty::Request::SharedPtr,
-          test_msgs::srv::Empty::Response::SharedPtr) {};
+      auto service_callback = [](
+        const test_msgs::srv::Empty::Request::SharedPtr,
+        test_msgs::srv::Empty::Response::SharedPtr) {};
       const rclcpp::QoS qos(10);
 
       service = node->create_service<test_msgs::srv::Empty>(

--- a/rclcpp/test/rclcpp/test_service.cpp
+++ b/rclcpp/test/rclcpp/test_service.cpp
@@ -88,12 +88,11 @@ protected:
    Testing service construction and destruction.
  */
 TEST_F(TestService, construction_and_destruction) {
-  using rcl_interfaces::srv::ListParameters;
-  auto callback =
-    [](const ListParameters::Request::SharedPtr, ListParameters::Response::SharedPtr) {
-    };
+  auto callback = [](
+    const rcl_interfaces::srv::ListParameters::Request::SharedPtr,
+    rcl_interfaces::srv::ListParameters::Response::SharedPtr) {};
   {
-    auto service = node->create_service<ListParameters>("service", callback);
+    auto service = node->create_service<rcl_interfaces::srv::ListParameters>("service", callback);
     EXPECT_NE(nullptr, service->get_service_handle());
     const rclcpp::ServiceBase * const_service_base = service.get();
     EXPECT_NE(nullptr, const_service_base->get_service_handle());
@@ -102,7 +101,8 @@ TEST_F(TestService, construction_and_destruction) {
   {
     ASSERT_THROW(
     {
-      auto service = node->create_service<ListParameters>("invalid_service?", callback);
+      auto service = node->create_service<rcl_interfaces::srv::ListParameters>(
+        "invalid_service?", callback);
     }, rclcpp::exceptions::InvalidServiceNameError);
   }
 }
@@ -111,27 +111,27 @@ TEST_F(TestService, construction_and_destruction) {
    Testing service construction and destruction for subnodes.
  */
 TEST_F(TestServiceSub, construction_and_destruction) {
-  using rcl_interfaces::srv::ListParameters;
-  auto callback =
-    [](const ListParameters::Request::SharedPtr, ListParameters::Response::SharedPtr) {
-    };
+  auto callback = [](
+    const rcl_interfaces::srv::ListParameters::Request::SharedPtr,
+    rcl_interfaces::srv::ListParameters::Response::SharedPtr) {};
   {
-    auto service = subnode->create_service<ListParameters>("service", callback);
+    auto service = subnode->create_service<rcl_interfaces::srv::ListParameters>(
+      "service", callback);
     EXPECT_STREQ(service->get_service_name(), "/ns/sub_ns/service");
   }
 
   {
     ASSERT_THROW(
     {
-      auto service = node->create_service<ListParameters>("invalid_service?", callback);
+      auto service = node->create_service<rcl_interfaces::srv::ListParameters>(
+        "invalid_service?", callback);
     }, rclcpp::exceptions::InvalidServiceNameError);
   }
 }
 
 TEST_F(TestService, construction_and_destruction_rcl_errors) {
-  auto callback =
-    [](const test_msgs::srv::Empty::Request::SharedPtr,
-      test_msgs::srv::Empty::Response::SharedPtr) {};
+  auto callback = [](
+    const test_msgs::srv::Empty::Request::SharedPtr, test_msgs::srv::Empty::Response::SharedPtr) {};
 
   {
     auto mock = mocking_utils::patch_and_return("lib:rclcpp", rcl_service_init, RCL_RET_ERROR);
@@ -149,11 +149,10 @@ TEST_F(TestService, construction_and_destruction_rcl_errors) {
 
 /* Testing basic getters */
 TEST_F(TestService, basic_public_getters) {
-  using rcl_interfaces::srv::ListParameters;
-  auto callback =
-    [](const ListParameters::Request::SharedPtr, ListParameters::Response::SharedPtr) {
-    };
-  auto service = node->create_service<ListParameters>("service", callback);
+  auto callback = [](
+    const rcl_interfaces::srv::ListParameters::Request::SharedPtr,
+    rcl_interfaces::srv::ListParameters::Response::SharedPtr) {};
+  auto service = node->create_service<rcl_interfaces::srv::ListParameters>("service", callback);
   EXPECT_STREQ(service->get_service_name(), "/ns/service");
   std::shared_ptr<rcl_service_t> service_handle = service->get_service_handle();
   EXPECT_NE(nullptr, service_handle);
@@ -189,9 +188,8 @@ TEST_F(TestService, basic_public_getters) {
 }
 
 TEST_F(TestService, take_request) {
-  auto callback =
-    [](const test_msgs::srv::Empty::Request::SharedPtr,
-      test_msgs::srv::Empty::Response::SharedPtr) {};
+  auto callback = [](
+    const test_msgs::srv::Empty::Request::SharedPtr, test_msgs::srv::Empty::Response::SharedPtr) {};
   auto server = node->create_service<test_msgs::srv::Empty>("service", callback);
   {
     auto request_id = server->create_request_header();
@@ -217,9 +215,8 @@ TEST_F(TestService, take_request) {
 }
 
 TEST_F(TestService, send_response) {
-  auto callback =
-    [](const test_msgs::srv::Empty::Request::SharedPtr,
-      test_msgs::srv::Empty::Response::SharedPtr) {};
+  auto callback = [](
+    const test_msgs::srv::Empty::Request::SharedPtr, test_msgs::srv::Empty::Response::SharedPtr) {};
   auto server = node->create_service<test_msgs::srv::Empty>("service", callback);
 
   {
@@ -243,9 +240,9 @@ TEST_F(TestService, send_response) {
    Testing on_new_request callbacks.
  */
 TEST_F(TestService, on_new_request_callback) {
-  auto server_callback =
-    [](const test_msgs::srv::Empty::Request::SharedPtr,
-      test_msgs::srv::Empty::Response::SharedPtr) {FAIL();};
+  auto server_callback = [](
+    const test_msgs::srv::Empty::Request::SharedPtr,
+    test_msgs::srv::Empty::Response::SharedPtr) {FAIL();};
   rclcpp::ServicesQoS service_qos;
   service_qos.keep_last(3);
   auto server = node->create_service<test_msgs::srv::Empty>(
@@ -315,9 +312,8 @@ TEST_F(TestService, on_new_request_callback) {
 TEST_F(TestService, rcl_service_response_publisher_get_actual_qos_error) {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_service_response_publisher_get_actual_qos, nullptr);
-  auto callback =
-    [](const test_msgs::srv::Empty::Request::SharedPtr,
-      test_msgs::srv::Empty::Response::SharedPtr) {};
+  auto callback = [](
+    const test_msgs::srv::Empty::Request::SharedPtr, test_msgs::srv::Empty::Response::SharedPtr) {};
   auto server = node->create_service<test_msgs::srv::Empty>("service", callback);
   RCLCPP_EXPECT_THROW_EQ(
     server->get_response_publisher_actual_qos(),
@@ -327,9 +323,8 @@ TEST_F(TestService, rcl_service_response_publisher_get_actual_qos_error) {
 TEST_F(TestService, rcl_service_request_subscription_get_actual_qos_error) {
   auto mock = mocking_utils::patch_and_return(
     "lib:rclcpp", rcl_service_request_subscription_get_actual_qos, nullptr);
-  auto callback =
-    [](const test_msgs::srv::Empty::Request::SharedPtr,
-      test_msgs::srv::Empty::Response::SharedPtr) {};
+  auto callback = [](
+    const test_msgs::srv::Empty::Request::SharedPtr, test_msgs::srv::Empty::Response::SharedPtr) {};
   auto server = node->create_service<test_msgs::srv::Empty>("service", callback);
   RCLCPP_EXPECT_THROW_EQ(
     server->get_request_subscription_actual_qos(),
@@ -345,11 +340,10 @@ TEST_F(TestService, server_qos) {
   qos_profile.lifespan(duration);
   qos_profile.liveliness_lease_duration(duration);
 
-  auto callback = [](const test_msgs::srv::Empty::Request::SharedPtr,
-      test_msgs::srv::Empty::Response::SharedPtr) {};
+  auto callback = [](
+    const test_msgs::srv::Empty::Request::SharedPtr, test_msgs::srv::Empty::Response::SharedPtr) {};
 
-  auto server = node->create_service<test_msgs::srv::Empty>(
-    "service", callback, qos_profile);
+  auto server = node->create_service<test_msgs::srv::Empty>("service", callback, qos_profile);
   auto rs_qos = server->get_request_subscription_actual_qos();
   auto rp_qos = server->get_response_publisher_actual_qos();
 
@@ -360,8 +354,6 @@ TEST_F(TestService, server_qos) {
 }
 
 TEST_F(TestService, server_qos_depth) {
-  using namespace std::literals::chrono_literals;
-
   uint64_t server_cb_count_ = 0;
   auto server_callback = [&](
     const test_msgs::srv::Empty::Request::SharedPtr,
@@ -380,8 +372,8 @@ TEST_F(TestService, server_qos_depth) {
   ::testing::AssertionResult request_result = ::testing::AssertionSuccess();
   auto request = std::make_shared<test_msgs::srv::Empty::Request>();
 
-  using SharedFuture = rclcpp::Client<test_msgs::srv::Empty>::SharedFuture;
-  auto client_callback = [&request_result](SharedFuture future_response) {
+  auto client_callback = [&request_result](
+    rclcpp::Client<test_msgs::srv::Empty>::SharedFuture future_response) {
       if (nullptr == future_response.get()) {
         request_result = ::testing::AssertionFailure() << "Future response was null";
       }

--- a/rclcpp/test/rclcpp/test_timer.cpp
+++ b/rclcpp/test/rclcpp/test_timer.cpp
@@ -285,20 +285,14 @@ TEST_P(TestTimer, test_failures_with_exceptions)
     std::shared_ptr<rclcpp::TimerBase> timer_to_test_destructor;
     // Test destructor failure, just logs a msg
     auto mock = mocking_utils::inject_on_return("lib:rclcpp", rcl_timer_fini, RCL_RET_ERROR);
-    EXPECT_NO_THROW(
-    {
-      switch (timer_type) {
-        case TimerType::WALL_TIMER:
-          timer_to_test_destructor =
-          test_node->create_wall_timer(std::chrono::milliseconds(0), [](void) {});
-          break;
-        case TimerType::GENERIC_TIMER:
-          timer_to_test_destructor =
-          test_node->create_timer(std::chrono::milliseconds(0), [](void) {});
-          break;
-      }
-      timer_to_test_destructor.reset();
-    });
+    if (timer_type == TimerType::WALL_TIMER) {
+      timer_to_test_destructor =
+        test_node->create_wall_timer(std::chrono::milliseconds(0), [](void) {});
+    } else {
+      timer_to_test_destructor =
+        test_node->create_timer(std::chrono::milliseconds(0), [](void) {});
+    }
+    timer_to_test_destructor.reset();
   }
   {
     auto mock = mocking_utils::patch_and_return(

--- a/rclcpp_action/test/test_client.cpp
+++ b/rclcpp_action/test/test_client.cpp
@@ -499,8 +499,7 @@ TEST_F(TestClientAgainstServer, async_send_goal_with_goal_response_callback_wait
   bool goal_response_received = false;
   auto send_goal_ops = rclcpp_action::Client<ActionType>::SendGoalOptions();
   send_goal_ops.goal_response_callback =
-    [&goal_response_received]
-      (typename ActionGoalHandle::SharedPtr goal_handle)
+    [&goal_response_received](typename ActionGoalHandle::SharedPtr goal_handle)
     {
       if (goal_handle) {
         goal_response_received = true;
@@ -545,8 +544,7 @@ TEST_F(TestClientAgainstServer, async_send_goal_with_feedback_callback_wait_for_
   goal.order = 4;
   int feedback_count = 0;
   auto send_goal_ops = rclcpp_action::Client<ActionType>::SendGoalOptions();
-  send_goal_ops.feedback_callback =
-    [&feedback_count](
+  send_goal_ops.feedback_callback = [&feedback_count](
     typename ActionGoalHandle::SharedPtr goal_handle,
     const std::shared_ptr<const ActionFeedback> feedback)
     {
@@ -868,9 +866,9 @@ TEST_F(TestClientAgainstServer, deadlock_in_callbacks)
 
       using GoalHandle = rclcpp_action::ClientGoalHandle<ActionType>;
       rclcpp_action::Client<ActionType>::SendGoalOptions ops;
-      ops.feedback_callback =
-      [&feedback_callback_called](const GoalHandle::SharedPtr handle,
-      ActionType::Feedback::ConstSharedPtr) {
+      ops.feedback_callback = [&feedback_callback_called](
+        const GoalHandle::SharedPtr handle, ActionType::Feedback::ConstSharedPtr)
+      {
         // call functions on the handle that acquire the lock
         handle->get_status();
         handle->is_feedback_aware();
@@ -940,9 +938,8 @@ TEST_F(TestClientAgainstServer, send_rcl_errors)
   auto send_goal_ops = rclcpp_action::Client<ActionType>::SendGoalOptions();
   send_goal_ops.result_callback =
     [](const typename ActionGoalHandle::WrappedResult &) {};
-  send_goal_ops.feedback_callback =
-    [](typename ActionGoalHandle::SharedPtr,
-      const std::shared_ptr<const ActionFeedback>) {};
+  send_goal_ops.feedback_callback = [](
+    typename ActionGoalHandle::SharedPtr, const std::shared_ptr<const ActionFeedback>) {};
 
   {
     ActionGoal goal;
@@ -982,9 +979,8 @@ TEST_F(TestClientAgainstServer, execute_rcl_errors)
   auto send_goal_ops = rclcpp_action::Client<ActionType>::SendGoalOptions();
   send_goal_ops.result_callback =
     [](const typename ActionGoalHandle::WrappedResult &) {};
-  send_goal_ops.feedback_callback =
-    [](typename ActionGoalHandle::SharedPtr,
-      const std::shared_ptr<const ActionFeedback>) {};
+  send_goal_ops.feedback_callback = [](
+    typename ActionGoalHandle::SharedPtr, const std::shared_ptr<const ActionFeedback>) {};
 
   {
     ActionGoal goal;

--- a/rclcpp_components/cmake/rclcpp_components_register_node.cmake
+++ b/rclcpp_components/cmake/rclcpp_components_register_node.cmake
@@ -24,6 +24,8 @@
 # :type PLUGIN: string
 # :param EXECUTABLE: the node's executable name
 # :type EXECUTABLE: string
+# :param EXECUTOR: the C++ class name of the executor to use (blank uses SingleThreadedExecutor)
+# :type EXECUTOR: string
 # :param RESOURCE_INDEX: the ament resource index to register the components
 # :type RESOURCE_INDEX: string
 #


### PR DESCRIPTION
Hi, I'm  developed member of [CARET](https://github.com/tier4/caret) for real-time analysis using [ros2tracing](https://github.com/ros2/ros2_tracing). 

In communication through GenericPublisher/Subscription, message tracking was not possible due to a lack of trace data output.
In this PR, added trace points to the GenericPublisher and GenericSubscription.

- GenericPublisher
I added trace points as following.
   - [rclcpp_publish](https://github.com/ros2/ros2_tracing/blob/327e8dfbf0cab3ab3472be409b5d184e4c1eacb9/tracetools/src/tracetools.c#L130-L136)

- GenericSubscription
[there was a recent PR that made it go through AnySubscriptionCallback](https://github.com/ros2/rclcpp/pull/1928). This change caused [`callback`](https://github.com/ros2/rclcpp/blob/b007204fd83828c11f80bf4712d237bfb2431f6e/rclcpp/include/rclcpp/generic_subscription.hpp#L87-L91) to be captured by the lambda, resulting in it being copied. Therefore, even by adding init trace points as they were, we could not produce the expected behavior of ros2tracing.  So, I modified the constructor of GenericSubscription to prevent `callback` from being copied.
And, I added trace points as following.
   - [rclcpp_subscription_init](https://github.com/ros2/ros2_tracing/blob/327e8dfbf0cab3ab3472be409b5d184e4c1eacb9/tracetools/src/tracetools.c#L191-L198)
   - [rclcpp_subscription_callback_added](https://github.com/ros2/ros2_tracing/blob/327e8dfbf0cab3ab3472be409b5d184e4c1eacb9/tracetools/src/tracetools.c#L200-L207)


Additionally, with these changes, I submitted a PR to the following repository.
- rcl
https://github.com/ymski/rcl/pull/1
- rmw_fastdds
https://github.com/ymski/rmw_fastrtps/pull/1
- rmw_cyclonedds
https://github.com/ymski/rmw_cyclonedds/pull/1